### PR TITLE
Fix bug QUERY_THREAD_TIMEOUT out of range

### DIFF
--- a/packages/server/src/automations/steps/bash.js
+++ b/packages/server/src/automations/steps/bash.js
@@ -53,7 +53,7 @@ exports.run = async function ({ inputs, context }) {
       success = true
     try {
       stdout = execSync(command, {
-        timeout: environment.QUERY_THREAD_TIMEOUT || 500,
+        timeout: parseInt(environment.QUERY_THREAD_TIMEOUT) || 500,
       }).toString()
     } catch (err) {
       stdout = err.message


### PR DESCRIPTION
## Description
environment.QUERY_THREAD_TIMEOUT must be a unsigned integer, but environment.QUERY_THREAD_TIMEOUT now return a string 
lead to error The value of \"timeout\" is out of range. It must be an unsigned integer. Received '10000'"

This is minor fix for [#5267](https://github.com/Budibase/budibase/pull/5267)

## Screenshots
![image](https://user-images.githubusercontent.com/4613808/164557465-14452a27-77e1-46fc-8188-6d7970f6efeb.png)



