### PR TITLE
Fix bug export CSV file does not follow charset encoding

### DIFF
--- a/packages/server/src/utilities/fileSystem/index.js
+++ b/packages/server/src/utilities/fileSystem/index.js
@@ -106,8 +106,10 @@ exports.loadHandlebarsFile = path => {
  */
 exports.apiFileReturn = contents => {
   const path = join(budibaseTempDir(), uuid())
-  fs.writeFileSync(path, contents)
-  return fs.createReadStream(path)
+  fs.writeFileSync(path, "\ufeff" + contents);
+  let readerStream = fs.createReadStream(path);
+  readerStream.setEncoding('binary');
+  return readerStream;
 }
 
 exports.defineFilter = excludeRows => {


### PR DESCRIPTION
## Description
Fix bug export CSV file does not follow charset encoding UTF-8 with BOM

Addresses: 
Issue raised here #3844

## Screenshots
Before:
<img width="341" alt="image" src="https://user-images.githubusercontent.com/4613808/173251141-b4bd9204-a5ea-4103-b367-f53e3d4dacdc.png">

Fixed:
<img width="340" alt="image" src="https://user-images.githubusercontent.com/4613808/173251167-75294030-a674-40a7-88eb-50e95a669038.png">





